### PR TITLE
Improve search query normalization and slug sanitation tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "npm run build && npm run preview",
     "debug:tags": "astro run scripts/debug-tags.ts",
     "linkcheck:internal": "node scripts/link-report.js internal",
-    "linkcheck:external": "node scripts/link-report.js external"
+    "linkcheck:external": "node scripts/link-report.js external",
+    "test": "node --loader ts-node/esm tests/run-tests.ts"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -6,9 +6,10 @@ import type { BlogPost } from '../utils/text';
 
 interface Props {
   post: BlogPost;
+  hidden?: boolean;
 }
 
-const { post } = Astro.props;
+const { post, hidden = false } = Astro.props;
 const title = post.data.title ?? 'Untitled';
 const desc = post.data.description ?? '';
 const category = post.data.category ?? '';
@@ -23,7 +24,11 @@ const href = `/writing/${slug}/`;
 const thumbnail = post.data.heroImage ?? SITE_OG_IMAGE;
 ---
 
-<article class="post-card">
+<article
+  class="post-card"
+  style={hidden ? 'display: none;' : undefined}
+  data-initially-hidden={hidden ? 'true' : undefined}
+>
   <a href={href} class="thumb-link">
     {
       typeof thumbnail === 'object' ? (

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,6 +1,7 @@
 import { getCollection } from 'astro:content';
 import rss from '@astrojs/rss';
 import { SITE_DESCRIPTION, SITE_TITLE, SITE_URL } from '../consts';
+import { getCleanSlug } from '../utils/slug';
 
 export async function GET() {
   const posts = await getCollection('blog');
@@ -11,7 +12,7 @@ export async function GET() {
     site: SITE_URL,
     items: posts.map((post) => {
       // fallback to post.id if slug isn’t available
-      const slug = post.slug ?? post.id.replace(/\.md$/, '');
+      const slug = getCleanSlug(post);
       return {
         title: post.data.title,
         description: post.data.description,

--- a/src/pages/search-index.json.js
+++ b/src/pages/search-index.json.js
@@ -1,6 +1,7 @@
 /* global Response */
 // src/pages/search-index.json.js
 import { getCollection } from 'astro:content';
+import { getCleanSlug } from '../utils/slug';
 
 export async function GET() {
   const posts = await getCollection('blog');
@@ -8,7 +9,7 @@ export async function GET() {
   const index = posts.map((post) => ({
     id: post.id,
     title: post.data.title,
-    url: `/writing/${post.slug}/`,
+    url: `/writing/${getCleanSlug(post)}/`,
     date: post.data.pubDate ? post.data.pubDate.toISOString() : null,
     content: post.body, // raw markdown
     category: post.data.category, // ✅ include category

--- a/src/pages/writing/search.astro
+++ b/src/pages/writing/search.astro
@@ -5,6 +5,7 @@ import { getCollection } from 'astro:content';
 import { SITE_TITLE } from '../../consts';
 import SearchBar from '../../components/SearchBar.astro';
 import { enrichPost } from '../../utils/text'; // ✅ reuse helper
+import { searchPosts } from '../../utils/search';
 
 // Extract query param `q` from the URL
 const url = new URL(Astro.request.url);
@@ -16,6 +17,9 @@ const allPosts = await getCollection('blog');
 const posts = allPosts
   .map(enrichPost)
   .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+
+const filteredPosts = q ? searchPosts(posts, q) : posts;
+const visibleIds = new Set(filteredPosts.map((post) => post.id));
 ---
 
 <BaseLayout
@@ -28,8 +32,19 @@ const posts = allPosts
   </div>
 
   <div id="post-list">
-    {posts.map((post) => <PostCard post={post} />)}
+    {posts.map((post) => (
+      <PostCard post={post} hidden={!visibleIds.has(post.id)} />
+    ))}
   </div>
+
+  <p
+    id="search-empty"
+    class:list={['search-empty', filteredPosts.length === 0 && q ? 'is-visible' : '']}
+    role="status"
+    aria-live="polite"
+  >
+    No posts found for “{q}”. Try a different keyword.
+  </p>
 
   <script src="https://cdn.jsdelivr.net/npm/fuse.js@7.0.0/dist/fuse.min.js"
   ></script>
@@ -37,6 +52,7 @@ const posts = allPosts
     const input = document.getElementById('client-search-input');
     const postList = document.getElementById('post-list');
     const allPosts = Array.from(postList.children);
+    const emptyState = document.getElementById('search-empty');
 
     const postsData = allPosts.map((el) => ({
       el,
@@ -64,12 +80,29 @@ const posts = allPosts
 
     function runSearch(query) {
       if (!query) {
-        allPosts.forEach((el) => (el.style.display = ''));
+        allPosts.forEach(showPost);
+        updateEmptyState(true);
         return;
       }
       const found = fuse.search(query).map((r) => r.item.el);
-      allPosts.forEach((el) => (el.style.display = 'none'));
-      found.forEach((el) => (el.style.display = ''));
+      allPosts.forEach(hidePost);
+      found.forEach(showPost);
+      updateEmptyState(found.length > 0);
+    }
+
+    function showPost(el) {
+      el.style.display = '';
+      el.removeAttribute('data-initially-hidden');
+    }
+
+    function hidePost(el) {
+      el.style.display = 'none';
+      el.setAttribute('data-initially-hidden', 'true');
+    }
+
+    function updateEmptyState(hasResults) {
+      if (!emptyState) return;
+      emptyState.classList.toggle('is-visible', !hasResults);
     }
   </script>
 </BaseLayout>
@@ -121,5 +154,14 @@ const posts = allPosts
     display: grid;
     gap: 1.5rem;
     width: 100%;
+  }
+  .search-empty {
+    display: none;
+    margin-top: 1.5rem;
+    font-style: italic;
+    color: var(--color-text-dimmed);
+  }
+  .search-empty.is-visible {
+    display: block;
   }
 </style>

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,0 +1,38 @@
+import type { BlogPost } from './text';
+
+function normalizeQuery(query: string): string {
+  return query
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, ' ');
+}
+
+/**
+ * Filter posts on the server to match the client-side Fuse.js behaviour.
+ * Ensures the search page returns relevant results even when JavaScript is disabled.
+ */
+export function searchPosts(posts: BlogPost[], query: string): BlogPost[] {
+  const normalizedQuery = normalizeQuery(query);
+  if (!normalizedQuery) {
+    return posts;
+  }
+
+  const terms = normalizedQuery.split(' ').filter(Boolean);
+
+  return posts.filter((post) => {
+    const haystack = [
+      post.data.title,
+      post.data.description,
+      post.data.category,
+      ...(post.data.tags ?? []),
+      post.body,
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase();
+
+    return terms.every((term) => haystack.includes(term));
+  });
+}
+
+export { normalizeQuery };

--- a/src/utils/slug-helpers.ts
+++ b/src/utils/slug-helpers.ts
@@ -1,0 +1,24 @@
+export interface SlugSourceLike {
+  id: string;
+  data: {
+    slug?: string;
+  };
+}
+
+/**
+ * Shared implementation for computing a clean slug from a content entry.
+ */
+export function computeCleanSlug(post: SlugSourceLike): string {
+  const explicitSlug = post.data?.slug;
+  if (typeof explicitSlug === 'string') {
+    const trimmed = explicitSlug.trim().replace(/^\/+|\/+$/g, '');
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  const raw = post.id
+    .replace(/\/index\.(md|mdx)$/i, '')
+    .replace(/\.(md|mdx)$/i, '');
+  return raw.replace(/^\d{4}_\d{2}_\d{2}_/, '');
+}

--- a/src/utils/slug.ts
+++ b/src/utils/slug.ts
@@ -1,10 +1,8 @@
 import type { CollectionEntry } from 'astro:content';
+import { computeCleanSlug } from './slug-helpers';
 
 export function getCleanSlug(post: CollectionEntry<'blog'>): string {
-  // Use frontmatter override if present
-  if (post.data.slug) return post.data.slug;
-
-  // Fallback: folder name without yyyy_mm_dd_
-  const raw = post.id.replace(/\/index\.md$/, '').replace(/\.md$/, '');
-  return raw.replace(/^\d{4}_\d{2}_\d{2}_/, '');
+  return computeCleanSlug(post);
 }
+
+export { computeCleanSlug };

--- a/tests/run-tests.ts
+++ b/tests/run-tests.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import { computeCleanSlug } from '../src/utils/slug-helpers.ts';
+import { searchPosts, normalizeQuery } from '../src/utils/search.ts';
+
+function makePost(overrides: Record<string, any> = {}) {
+  const base = {
+    id: '2024_01_01_sample/index.md',
+    slug: 'sample',
+    body: 'Base body',
+    collection: 'blog',
+    data: {
+      title: 'Base Title',
+      description: 'Base description about finance',
+      pubDate: new Date('2024-01-01T00:00:00Z'),
+      updatedDate: undefined,
+      category: 'Finance',
+      categoryNormalized: 'finance',
+      readingTime: 3,
+      tags: ['compounding'],
+      heroImage: undefined,
+    },
+  };
+
+  return {
+    ...base,
+    ...overrides,
+    data: {
+      ...base.data,
+      ...(overrides.data ?? {}),
+    },
+  };
+}
+
+function makeEntry(overrides: Record<string, any> = {}) {
+  const base = {
+    id: '2024_01_01_sample/index.md',
+    data: {},
+  };
+
+  return {
+    ...base,
+    ...overrides,
+    data: {
+      ...(base.data ?? {}),
+      ...(overrides.data ?? {}),
+    },
+  };
+}
+
+function testSearchPosts() {
+  const posts = [
+    makePost(),
+    makePost({ id: '2024_01_02_other/index.md', slug: 'other' }),
+  ];
+  assert.deepEqual(searchPosts(posts as any, '   '), posts);
+
+  const shuffled = searchPosts(posts as any, 'base');
+  assert.deepEqual(
+    shuffled.map((p) => p.id),
+    posts.map((p) => p.id),
+  );
+
+  const detailedPosts = [
+    makePost({
+      id: '2024_01_02_growth/index.md',
+      slug: 'growth',
+      data: {
+        title: 'Growth Stocks',
+        description: 'Looking at multiples',
+        category: 'Markets',
+        tags: ['Equities'],
+      },
+      body: 'This essay analyses venture capital deal flow.',
+    }),
+    makePost({
+      id: '2024_01_03_notes/index.md',
+      slug: 'notes',
+      data: {
+        title: 'Weekly Notes',
+        description: 'Digest',
+        category: 'Notes',
+        tags: ['newsletter'],
+      },
+      body: 'miscellaneous thoughts',
+    }),
+  ];
+
+  assert.deepEqual(searchPosts(detailedPosts as any, 'venture'), [detailedPosts[0]]);
+  assert.deepEqual(searchPosts(detailedPosts as any, 'markets'), [detailedPosts[0]]);
+  assert.deepEqual(searchPosts(detailedPosts as any, 'equities'), [detailedPosts[0]]);
+  assert.deepEqual(searchPosts(detailedPosts as any, 'digest'), [detailedPosts[1]]);
+  assert.deepEqual(
+    searchPosts(detailedPosts as any, 'venture capital'),
+    [detailedPosts[0]],
+  );
+  assert.equal(searchPosts(detailedPosts as any, 'nonexistent').length, 0);
+}
+
+function testComputeCleanSlug() {
+  assert.equal(
+    computeCleanSlug(makeEntry({ data: { slug: 'custom-slug' } })),
+    'custom-slug',
+  );
+  assert.equal(
+    computeCleanSlug(makeEntry({ id: '2024_02_03_new-idea.md' })),
+    'new-idea',
+  );
+  assert.equal(
+    computeCleanSlug(makeEntry({ id: '2024_02_03_new-idea/index.md' })),
+    'new-idea',
+  );
+  assert.equal(
+    computeCleanSlug(
+      makeEntry({ id: '2024_02_03_new-idea/index.mdx' }),
+    ),
+    'new-idea',
+  );
+  assert.equal(
+    computeCleanSlug(
+      makeEntry({ data: { slug: '  /custom-slug/ ' } }),
+    ),
+    'custom-slug',
+  );
+}
+
+function testNormalizeQuery() {
+  assert.equal(normalizeQuery('   Venture   Deals  '), 'venture deals');
+  assert.equal(normalizeQuery('\n\t  MIXED Case  '), 'mixed case');
+}
+
+try {
+  testSearchPosts();
+  testComputeCleanSlug();
+  testNormalizeQuery();
+  console.log('✅ All custom tests passed');
+} catch (error) {
+  console.error('❌ Test failure', error);
+  process.exitCode = 1;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,6 @@
     "strictNullChecks": true,
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
-    "types": ["@astrojs/preact"]
+    "types": ["@astrojs/preact", "node"]
   }
 }


### PR DESCRIPTION
## Summary
- normalize server search queries by collapsing whitespace and matching on individual terms so multi-word queries behave closer to the fuzzy client search
- harden clean-slug helper to trim custom slugs, strip leading/trailing slashes, and handle `.mdx` sources
- expand the TypeScript smoke tests to cover the new slug cases, search ordering, multi-term queries, and query normalization

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d761daf44c8324af9cd7a7df17be36