### PR TITLE
Fix tag page post links

### DIFF
--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -3,6 +3,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import PostList from '../../components/PostList.astro';
 import { getCollection } from 'astro:content';
 import { SITE_TITLE } from '../../consts';
+import { enrichPost } from '../../utils/text';
 
 // Build paths for each tag
 export async function getStaticPaths() {
@@ -15,9 +16,12 @@ export async function getStaticPaths() {
 }
 
 const { tag } = Astro.props;
-const posts = (await getCollection('blog')).filter((post) =>
-  post.data.tags?.map((t) => t.toLowerCase()).includes(tag.toLowerCase()),
-);
+const posts = (await getCollection('blog'))
+  .map(enrichPost)
+  .filter((post) =>
+    post.data.tags?.map((t) => t.toLowerCase()).includes(tag.toLowerCase()),
+  )
+  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 ---
 
 <BaseLayout


### PR DESCRIPTION
## Summary
- enrich tag page posts so PostCards receive clean slugs
- sort tagged posts by publication date for consistent ordering

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68d7e66899b88324ad719a30bf7e43d2