### PR TITLE
Improve content utilities and expand tests

### DIFF
--- a/src/utils/hero-image.ts
+++ b/src/utils/hero-image.ts
@@ -1,0 +1,47 @@
+import { posix as path } from 'node:path';
+
+export type HeroImageLike = unknown;
+
+function stripIndexSuffix(postId: string): string {
+  return postId
+    .replace(/\/index\.(md|mdx)$/i, '')
+    .replace(/\.(md|mdx)$/i, '');
+}
+
+function normalizeRelativePath(heroImage: string, postId: string): string {
+  const baseDir = stripIndexSuffix(postId);
+  const cleaned = heroImage.replace(/^\.\//, '');
+  return path
+    .join('/', baseDir, cleaned)
+    .replace(/\\/g, '/');
+}
+
+export function normalizeHeroImage(
+  heroImage: HeroImageLike,
+  postId: string,
+): string | HeroImageLike | undefined {
+  if (!heroImage) return undefined;
+
+  if (
+    typeof heroImage === 'object' &&
+    heroImage !== null &&
+    'src' in heroImage &&
+    'width' in heroImage &&
+    'height' in heroImage &&
+    'format' in heroImage
+  ) {
+    return heroImage;
+  }
+
+  if (typeof heroImage === 'string') {
+    if (heroImage.startsWith('./') || heroImage.startsWith('../')) {
+      return normalizeRelativePath(heroImage, postId);
+    }
+
+    return heroImage;
+  }
+
+  return undefined;
+}
+
+export { normalizeRelativePath, stripIndexSuffix };

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -2,6 +2,7 @@ import { getCollection, type CollectionEntry } from 'astro:content';
 import readingTime from 'reading-time';
 import type { ImageMetadata } from 'astro';
 import { getCleanSlug } from './slug';
+import { normalizeHeroImage } from './hero-image';
 
 export type BlogPost = CollectionEntry<'blog'> & {
   slug: string;
@@ -52,45 +53,12 @@ export function enrichPost(p: CollectionEntry<'blog'>): BlogPost {
       categoryNormalized: normalizeCategory(p.data.category ?? ''),
       readingTime: Math.max(1, Math.round(readingTime(p.body ?? '').minutes)),
       tags: Array.isArray(p.data.tags) ? p.data.tags : [],
-      heroImage: normalizeHeroImage(p.data.heroImage, p.id),
+      heroImage: normalizeHeroImage(p.data.heroImage, p.id) as
+        | ImageMetadata
+        | string
+        | undefined,
     },
   };
-}
-
-/**
- * Normalize heroImage field to either ImageMetadata or string URL
- */
-function normalizeHeroImage(
-  heroImage: unknown,
-  postId: string,
-): ImageMetadata | string | undefined {
-  if (!heroImage) return undefined;
-
-  // If it's already an Astro ImageMetadata object
-  if (
-    typeof heroImage === 'object' &&
-    heroImage !== null &&
-    'src' in heroImage &&
-    'width' in heroImage &&
-    'height' in heroImage &&
-    'format' in heroImage
-  ) {
-    return heroImage as ImageMetadata;
-  }
-
-  // If it's a string path (e.g., "./ergo_5.webp")
-  if (typeof heroImage === 'string') {
-    // Resolve relative paths against the post folder
-    if (heroImage.startsWith('./') || heroImage.startsWith('../')) {
-      // Example: "blog/2021_04_03_ergodicity/index.md" → "blog/2021_04_03_ergodicity/"
-      const baseDir = postId.replace(/\/index\.md$/, '').replace(/\.md$/, '');
-      return `/${baseDir}/${heroImage.replace(/^\.\//, '')}`;
-    }
-    // Otherwise assume it's already a valid path (e.g., "/images/foo.webp")
-    return heroImage;
-  }
-
-  return undefined;
 }
 
 /**

--- a/src/utils/toc.ts
+++ b/src/utils/toc.ts
@@ -9,15 +9,15 @@ export interface Heading {
  * Returns an array of { level, id, text } objects.
  */
 export function extractHeadings(html: string): Heading[] {
-  const regex = /<h([2-3])\s+id="([^"]+)">(.*?)<\/h\1>/g;
+  const regex = /<h([2-3])\b[^>]*\sid=(['"])([^'"<>]+)\2[^>]*>(.*?)<\/h\1>/gis;
   const headings: Heading[] = [];
   let match;
 
   while ((match = regex.exec(html))) {
     headings.push({
       level: Number(match[1]),
-      id: match[2],
-      text: stripTags(match[3]),
+      id: match[3],
+      text: stripTags(match[4]),
     });
   }
 


### PR DESCRIPTION
## Summary
- extract hero image normalization into a dedicated helper that supports `.mdx` entries and normalizes relative paths
- tighten heading extraction logic so ids are detected regardless of attribute order and add coverage for nested markup
- expand the lightweight test runner with cases for heading extraction and hero image normalization regressions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d7f1580f408324bf37622ba1413027