### PR TITLE
Fix search input contrast in dark mode

### DIFF
--- a/src/pages/writing/search.astro
+++ b/src/pages/writing/search.astro
@@ -135,6 +135,9 @@ const visibleIds = new Set(filteredPosts.map((post) => post.id));
     font-size: 0.95rem;
     width: 100%;
     box-sizing: border-box;
+    color: var(--color-text);
+    background: transparent;
+    caret-color: var(--color-text);
   }
   .search-btn {
     padding: 0.35rem 0.75rem;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -12,6 +12,7 @@
   /* Colors */
   --color-bg: #ffffff;
   --color-text: #222222;
+  --color-text-subtle: #666666;
   --color-link: #0066cc;
   --color-link-hover: #005bb5;
   --color-border: #e0e0e0;
@@ -63,6 +64,7 @@
 [data-theme='dark'] {
   --color-bg: #111111;
   --color-text: #f5f5f5;
+  --color-text-subtle: rgba(245, 245, 245, 0.64);
   --color-link: #4ea1ff;
   --color-link-hover: #80c2ff;
   --color-border: #333333;
@@ -485,6 +487,8 @@ img.center {
   border: none;
   outline: none;
   background: transparent;
+  color: var(--color-text);
+  caret-color: var(--color-text);
   font-size: var(--text-base);
   flex: 1;
   padding: 0.5rem 0; /* balanced vertical padding */


### PR DESCRIPTION
## Summary
- add dark-mode friendly text and placeholder color tokens for the global search input
- ensure search inputs inherit the current theme text color so entries stay legible on dark backgrounds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d7f286384483249784f7b8d2235963