### PR TITLE
Expand blog utility tests and test harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "debug:tags": "astro run scripts/debug-tags.ts",
     "linkcheck:internal": "node scripts/link-report.js internal",
     "linkcheck:external": "node scripts/link-report.js external",
-    "test": "node --loader ts-node/esm tests/run-tests.ts"
+    "test": "TS_NODE_PROJECT=tsconfig.test.json node --loader ts-node/esm tests/run-tests.ts"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",

--- a/src/utils/slug.ts
+++ b/src/utils/slug.ts
@@ -1,5 +1,5 @@
 import type { CollectionEntry } from 'astro:content';
-import { computeCleanSlug } from './slug-helpers';
+import { computeCleanSlug } from './slug-helpers.ts';
 
 export function getCleanSlug(post: CollectionEntry<'blog'>): string {
   return computeCleanSlug(post);

--- a/tests/mocks/astro-content.ts
+++ b/tests/mocks/astro-content.ts
@@ -1,0 +1,15 @@
+export interface CollectionEntry<CollectionName extends string = string> {
+  id: string;
+  slug?: string;
+  body: string;
+  collection: CollectionName;
+  data: Record<string, any>;
+}
+
+export async function getCollection<CollectionName extends string = string>(
+  _collection: CollectionName,
+): Promise<CollectionEntry<CollectionName>[]> {
+  throw new Error(
+    'getCollection is not implemented. Use setGetCollectionImplementation() to supply a stub in tests.',
+  );
+}

--- a/tests/run-tests.ts
+++ b/tests/run-tests.ts
@@ -1,6 +1,26 @@
 import assert from 'node:assert/strict';
 import { computeCleanSlug } from '../src/utils/slug-helpers.ts';
 import { searchPosts, normalizeQuery } from '../src/utils/search.ts';
+import {
+  enrichPost,
+  getAllPostsPaginated,
+  getCategoryPostsPaginated,
+  normalizeCategory,
+  setGetCollectionImplementation,
+  titleCase,
+  type BlogPost,
+} from '../src/utils/text.ts';
+import { extractHeadings } from '../src/utils/toc.ts';
+
+process.on('uncaughtException', (error) => {
+  console.error('❌ Uncaught exception', error);
+  process.exitCode = 1;
+});
+
+process.on('unhandledRejection', (reason) => {
+  console.error('❌ Unhandled rejection', reason);
+  process.exitCode = 1;
+});
 
 function makePost(overrides: Record<string, any> = {}) {
   const base = {
@@ -17,6 +37,33 @@ function makePost(overrides: Record<string, any> = {}) {
       categoryNormalized: 'finance',
       readingTime: 3,
       tags: ['compounding'],
+      heroImage: undefined,
+    },
+  };
+
+  return {
+    ...base,
+    ...overrides,
+    data: {
+      ...base.data,
+      ...(overrides.data ?? {}),
+    },
+  };
+}
+
+function makeCollectionEntry(overrides: Record<string, any> = {}) {
+  const base = {
+    id: '2024_01_01_sample/index.md',
+    slug: 'sample',
+    body: 'Sample body for reading time calculations.',
+    collection: 'blog',
+    data: {
+      title: 'Sample Title',
+      description: 'Sample description',
+      pubDate: new Date('2024-01-01T00:00:00Z'),
+      updatedDate: undefined,
+      category: 'Finance',
+      tags: ['markets'],
       heroImage: undefined,
     },
   };
@@ -128,12 +175,245 @@ function testNormalizeQuery() {
   assert.equal(normalizeQuery('\n\t  MIXED Case  '), 'mixed case');
 }
 
-try {
-  testSearchPosts();
-  testComputeCleanSlug();
-  testNormalizeQuery();
-  console.log('✅ All custom tests passed');
-} catch (error) {
-  console.error('❌ Test failure', error);
-  process.exitCode = 1;
+function testTitleCase() {
+  assert.equal(titleCase('hello world'), 'Hello World');
+  assert.equal(titleCase('multi\nline text'), 'Multi\nLine Text');
+  assert.equal(titleCase(''), '');
+  assert.equal(titleCase(undefined as any), '');
 }
+
+function testNormalizeCategory() {
+  assert.equal(normalizeCategory(' Finance '), 'finance');
+  assert.equal(normalizeCategory(undefined as any), '');
+}
+
+function testEnrichPost() {
+  const heroMeta = {
+    src: '/images/hero.webp',
+    width: 1200,
+    height: 630,
+    format: 'webp',
+  };
+
+  const baseEntry = makeCollectionEntry({
+    data: {
+      category: '  Markets  ',
+      tags: ['macro', 'rates'],
+      heroImage: heroMeta,
+    },
+  });
+
+  const enriched = enrichPost(baseEntry as any);
+
+  assert.equal(enriched.slug, computeCleanSlug(baseEntry as any));
+  assert.equal(enriched.data.category, 'Markets');
+  assert.equal(enriched.data.categoryNormalized, 'markets');
+  assert.deepEqual(enriched.data.tags, ['macro', 'rates']);
+  assert.equal(enriched.data.heroImage, heroMeta);
+  assert.ok(enriched.data.readingTime >= 1);
+
+  const relativeEntry = makeCollectionEntry({
+    id: '2024_05_02_custom/index.md',
+    data: {
+      category: 'Notes',
+      tags: 'not-array',
+      heroImage: './cover.webp',
+    },
+  });
+
+  const relativeHero = enrichPost(relativeEntry as any);
+
+  assert.equal(relativeHero.slug, computeCleanSlug(relativeEntry as any));
+  assert.deepEqual(relativeHero.data.tags, []);
+  assert.equal(relativeHero.data.heroImage, '/2024_05_02_custom/cover.webp');
+
+  const absoluteEntry = makeCollectionEntry({
+    id: '2024_05_03_absolute.md',
+    data: {
+      heroImage: '/images/custom.png',
+    },
+  });
+
+  const absoluteHero = enrichPost(absoluteEntry as any);
+
+  assert.equal(absoluteHero.data.heroImage, '/images/custom.png');
+}
+
+async function testGetAllPostsPaginated() {
+  const posts = [
+    makeCollectionEntry({
+      id: '2024_06_01_first/index.md',
+      data: {
+        title: 'First',
+        category: ' Finance ',
+        pubDate: new Date('2024-06-01T00:00:00Z'),
+      },
+    }),
+    makeCollectionEntry({
+      id: '2024_06_10_second/index.md',
+      data: {
+        title: 'Second',
+        category: 'Markets',
+        pubDate: new Date('2024-06-10T00:00:00Z'),
+      },
+    }),
+    makeCollectionEntry({
+      id: '2024_05_01_third/index.md',
+      data: {
+        title: 'Third',
+        category: 'finance',
+        pubDate: new Date('2024-05-01T00:00:00Z'),
+      },
+    }),
+  ];
+
+  setGetCollectionImplementation(async (collection) => {
+    assert.equal(collection, 'blog');
+    return posts as any;
+  });
+
+  try {
+    const paginateCalls: any[] = [];
+    const paginate = ((items: BlogPost[], options: any) => {
+      paginateCalls.push({ items, options });
+      const chunks = [] as any[];
+      for (let i = 0; i < items.length; i += options.pageSize) {
+        chunks.push({
+          props: {
+            pageNumber: chunks.length + 1,
+            items: items.slice(i, i + options.pageSize),
+          },
+        });
+      }
+      return chunks;
+    }) as any;
+
+    const { pages, categories } = await getAllPostsPaginated(paginate, 2);
+
+    assert.deepEqual(categories, ['finance', 'markets']);
+    assert.equal(paginateCalls.length, 1);
+    assert.equal(paginateCalls[0].options.pageSize, 2);
+    assert.deepEqual(
+      pages.map((page) => page.props.items.map((post: BlogPost) => post.data.title)),
+      [
+        ['Second', 'First'],
+        ['Third'],
+      ],
+    );
+  } finally {
+    setGetCollectionImplementation(null);
+  }
+}
+
+async function testGetCategoryPostsPaginated() {
+  const posts = [
+    makeCollectionEntry({
+      id: '2024_01_01_alpha/index.md',
+      data: {
+        title: 'Alpha',
+        category: 'Finance',
+        pubDate: new Date('2024-01-01T00:00:00Z'),
+      },
+    }),
+    makeCollectionEntry({
+      id: '2024_02_01_beta/index.md',
+      data: {
+        title: 'Beta',
+        category: 'Finance',
+        pubDate: new Date('2024-02-01T00:00:00Z'),
+      },
+    }),
+    makeCollectionEntry({
+      id: '2024_03_01_gamma/index.md',
+      data: {
+        title: 'Gamma',
+        category: 'Markets',
+        pubDate: new Date('2024-03-01T00:00:00Z'),
+      },
+    }),
+  ];
+
+  setGetCollectionImplementation(async () => posts as any);
+
+  try {
+    const paginateHistory: any[] = [];
+    const paginate = ((items: BlogPost[], options: any) => {
+      paginateHistory.push({ items, options });
+      return [
+        {
+          props: {
+            pageItems: items,
+          },
+        },
+      ];
+    }) as any;
+
+    const routes = await getCategoryPostsPaginated(paginate, 10);
+
+    assert.equal(routes.length, 2);
+    assert.deepEqual(
+      routes.map((route) => ({
+        activeCategory: route.props.activeCategory,
+        titles: route.props.pageItems.map((p: BlogPost) => p.data.title),
+        categories: route.props.categories,
+      })),
+      [
+        {
+          activeCategory: 'finance',
+          titles: ['Beta', 'Alpha'],
+          categories: ['finance', 'markets'],
+        },
+        {
+          activeCategory: 'markets',
+          titles: ['Gamma'],
+          categories: ['finance', 'markets'],
+        },
+      ],
+    );
+
+    assert.deepEqual(
+      paginateHistory.map((call) => call.options.params.category),
+      ['finance', 'markets'],
+    );
+  } finally {
+    setGetCollectionImplementation(null);
+  }
+}
+
+function testExtractHeadings() {
+  const html = `
+    <h1 id="title">Main</h1>
+    <h2 id="intro">Intro <em>section</em></h2>
+    <h3 id="details">Details <code>code</code></h3>
+    <h4 id="ignore">Ignore</h4>
+  `;
+
+  const headings = extractHeadings(html);
+  assert.deepEqual(headings, [
+    { level: 2, id: 'intro', text: 'Intro section' },
+    { level: 3, id: 'details', text: 'Details code' },
+  ]);
+}
+
+async function run() {
+  try {
+    testSearchPosts();
+    testComputeCleanSlug();
+    testNormalizeQuery();
+    testTitleCase();
+    testNormalizeCategory();
+    testEnrichPost();
+    await testGetAllPostsPaginated();
+    await testGetCategoryPostsPaginated();
+    testExtractHeadings();
+    console.log('✅ All custom tests passed');
+  } catch (error) {
+    console.error('❌ Test failure', error);
+    process.exitCode = 1;
+  }
+}
+
+run().catch((error) => {
+  console.error('❌ Unhandled failure', error);
+  process.exitCode = 1;
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "astro:content": ["tests/mocks/astro-content.ts"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a test-specific tsconfig and astro:content stub so the unit suite can run without Astro's runtime
- extend the custom test runner to cover text utilities, pagination helpers, and table-of-contents extraction
- update blog utility modules to support lazy getCollection injection and ensure ESM-compatible import paths

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d80a360d3c832481f83d8854a1e3d4