### PR TITLE
Refine writing archive metadata and logo accessibility

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -5,19 +5,59 @@ import {
   SITE_DESCRIPTION,
   SITE_URL,
   SITE_OG_IMAGE,
+  SITE_AUTHOR,
 } from "../consts";
 
-interface Props {
+const {
+  title,
+  description,
+  image,
+  pubDate,
+  updatedDate,
+  authorName,
+  ogType = "website",
+  tags = [],
+  canonical,
+  relPrev,
+  relNext,
+} = Astro.props as {
   title: string;
   description?: string;
   image?: string | { src: string };
   pubDate?: Date;
   updatedDate?: Date;
   authorName?: string;
-}
+  ogType?: string;
+  tags?: string[];
+  canonical?: string;
+  relPrev?: string;
+  relNext?: string;
+};
 
-const canonicalURL = new URL(Astro.url.pathname, SITE_URL).toString();
-const { title, description, image, pubDate, updatedDate, authorName } = Astro.props;
+const resolveAbsoluteURL = (maybeRelative?: string) => {
+  if (!maybeRelative) return undefined;
+  if (maybeRelative.startsWith("http")) return maybeRelative;
+  try {
+    return new URL(maybeRelative, SITE_URL).toString();
+  } catch (error) {
+    return undefined;
+  }
+};
+
+const canonicalURL =
+  resolveAbsoluteURL(canonical) ?? new URL(Astro.url.pathname, SITE_URL).toString();
+const prevURL = resolveAbsoluteURL(relPrev);
+const nextURL = resolveAbsoluteURL(relNext);
+
+const normalizedTags = Array.isArray(tags)
+  ? tags.map((tag) => tag?.toString().trim()).filter(Boolean)
+  : [];
+const resolvedAuthor = authorName || SITE_AUTHOR;
+const isoPubDate = pubDate instanceof Date ? pubDate.toISOString() : undefined;
+const isoUpdatedDate =
+  updatedDate instanceof Date
+    ? updatedDate.toISOString()
+    : isoPubDate;
 
 // ✅ Resolve OG image safely
 let ogImage: string;
@@ -62,7 +102,7 @@ if (pubDate) {
     dateModified: (updatedDate || pubDate).toISOString(),
     author: {
       "@type": "Person",
-      name: authorName || "Leon Lin",
+      name: resolvedAuthor,
     },
     publisher: {
       "@type": "Organization",
@@ -80,7 +120,12 @@ if (pubDate) {
 }
 
 // ✅ Merge schemas into one JSON-LD array
+if (articleSchema && normalizedTags.length > 0) {
+  articleSchema.keywords = normalizedTags.join(", ");
+}
+
 const structuredData = articleSchema ? [orgSchema, articleSchema] : [orgSchema];
+const ogImageAlt = `Preview image for ${title}`;
 ---
 
 <!-- Global Metadata -->
@@ -115,19 +160,37 @@ const structuredData = articleSchema ? [orgSchema, articleSchema] : [orgSchema];
 
 <!-- Canonical URL -->
 <link rel="canonical" href={canonicalURL} />
+{prevURL && <link rel="prev" href={prevURL} />}
+{nextURL && <link rel="next" href={nextURL} />}
 
 <!-- Primary Meta Tags -->
 <title>{title}</title>
 <meta name="title" content={title} />
 <meta name="description" content={metaDescription} />
+<meta name="author" content={resolvedAuthor} />
 
 <!-- Open Graph -->
-<meta property="og:type" content="website" />
+<meta property="og:type" content={ogType} />
+<meta property="og:locale" content="en_US" />
 <meta property="og:url" content={canonicalURL} />
 <meta property="og:title" content={title} />
 <meta property="og:description" content={metaDescription} />
 <meta property="og:image" content={ogImage} />
+<meta property="og:image:alt" content={ogImageAlt} />
 <meta property="og:site_name" content={SITE_TITLE} />
+{ogType === "article" && isoPubDate && (
+  <meta property="article:published_time" content={isoPubDate} />
+)}
+{ogType === "article" && isoUpdatedDate && (
+  <meta property="article:modified_time" content={isoUpdatedDate} />
+)}
+{ogType === "article" && (
+  <meta property="article:author" content={resolvedAuthor} />
+)}
+{ogType === "article" &&
+  normalizedTags.map((tag) => (
+    <meta property="article:tag" content={tag} key={tag} />
+  ))}
 
 <!-- Twitter -->
 <meta name="twitter:card" content="summary_large_image" />
@@ -135,6 +198,7 @@ const structuredData = articleSchema ? [orgSchema, articleSchema] : [orgSchema];
 <meta name="twitter:title" content={title} />
 <meta name="twitter:description" content={metaDescription} />
 <meta name="twitter:image" content={ogImage} />
+<meta name="twitter:image:alt" content={ogImageAlt} />
 <meta name="twitter:creator" content="@leonlinsx" />
 <meta name="twitter:site" content="@leonlinsx" />
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -14,7 +14,8 @@ const { currentPath } = Astro.props;
     <a href="/" class="site-logo" aria-label={SITE_TITLE}>
       <img
         src="/logos/substack_logo.webp"
-        alt={SITE_TITLE}
+        alt=""
+        aria-hidden="true"
         width="32"
         height="32"
       />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,14 +3,38 @@ import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import BaseHead from '../components/BaseHead.astro';
 
-const { title, description, image } = Astro.props;
+const {
+  title,
+  description,
+  image,
+  pubDate,
+  updatedDate,
+  authorName,
+  ogType,
+  tags,
+  canonical,
+  relPrev,
+  relNext,
+} = Astro.props;
 const GA_ID = import.meta.env.PUBLIC_GA_ID;
 const isProd = import.meta.env.PROD;
 ---
 
 <html lang="en">
   <head>
-    <BaseHead title={title} description={description} image={image} />
+    <BaseHead
+      title={title}
+      description={description}
+      image={image}
+      pubDate={pubDate}
+      updatedDate={updatedDate}
+      authorName={authorName}
+      ogType={ogType}
+      tags={tags}
+      canonical={canonical}
+      relPrev={relPrev}
+      relNext={relNext}
+    />
 
     {
       isProd && GA_ID && (

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -5,7 +5,7 @@ import { getCollection } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import FormattedDate from '../components/FormattedDate.astro';
 import PostList from '../components/PostList.astro';
-import { SITE_BANNER_IMAGE, SITE_URL } from '../consts';
+import { SITE_AUTHOR, SITE_BANNER_IMAGE, SITE_URL } from '../consts';
 import { enrichPost } from '../utils/text';
 import TableOfContents from '../components/TableOfContents.astro';
 import ShareButtons from '../components/ShareButtons.astro';
@@ -53,6 +53,11 @@ const canonicalURL = new URL(`/writing/${slug}/`, SITE_URL).toString();
   title={title}
   description={description}
   image={typeof hero === 'object' ? hero.src : hero}
+  pubDate={pubDate}
+  updatedDate={updatedDate}
+  authorName={SITE_AUTHOR}
+  ogType="article"
+  tags={tags}
 >
   <main>
     <article>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -78,9 +78,9 @@ const featured = allPosts
   <section class="featured">
     <h2>As featured in</h2>
     <div class="logo-row">
-      <img src="/logos/hacker_news_logo.webp" alt="HackerNews" />
-      <img src="/logos/failory_logo.webp" alt="Failory" />
-      <img src="/logos/finextra_logo.webp" alt="Finextra" />
+      <img src="/logos/hacker_news_logo.webp" alt="Hacker News logo" />
+      <img src="/logos/failory_logo.webp" alt="Failory logo" />
+      <img src="/logos/finextra_logo.webp" alt="Finextra logo" />
     </div>
   </section>
 </BaseLayout>

--- a/src/pages/writing/[page].astro
+++ b/src/pages/writing/[page].astro
@@ -26,11 +26,23 @@ const currentPage = page.currentPage;
 const totalPages = page.lastPage;
 
 const activeCategory = ''; // "All" page
+const canonical = currentPage === 1 ? '/writing/' : undefined;
+const relPrev =
+  currentPage > 1
+    ? currentPage === 2
+      ? '/writing/'
+      : `/writing/${currentPage - 1}`
+    : undefined;
+const relNext =
+  currentPage < totalPages ? `/writing/${currentPage + 1}` : undefined;
 ---
 
 <BaseLayout
   title={`Writing | ${SITE_TITLE}`}
   description="All essays, notes, and more."
+  canonical={canonical}
+  relPrev={relPrev}
+  relNext={relNext}
 >
   <WritingHeader
     title="Essays, Notes, and More"


### PR DESCRIPTION
## Summary
- allow BaseHead/BaseLayout to accept canonical and pagination overrides to support richer metadata on archives
- configure the writing archive to canonicalize page one to /writing/ and expose rel=prev/next links across pages
- improve logo accessibility by updating header branding alt/aria attributes and homepage logo alt text
- remove the earlier SEO review markdown per follow-up feedback

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d8691565ac8324b2b66a1b1f45158f