### PR TITLE
Retain SEO improvements without topic clusters

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -76,6 +76,8 @@ if (image) {
 }
 
 const metaDescription = description || SITE_DESCRIPTION;
+const keywordsContent =
+  normalizedTags.length > 0 ? normalizedTags.join(', ') : undefined;
 
 // ✅ Absolute URL for organization logo
 const orgLogo = new URL("/logos/substack_logo.webp", SITE_URL).toString();
@@ -133,6 +135,11 @@ const ogImageAlt = `Preview image for ${title}`;
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <meta name="color-scheme" content="light dark" />
 
+<!-- Performance hints for third-party scripts -->
+<link rel="preconnect" href="https://www.googletagmanager.com" crossorigin />
+<link rel="preconnect" href="https://www.clarity.ms" crossorigin />
+<link rel="preconnect" href="https://giscus.app" crossorigin />
+
 <!-- ✅ Preload Fonts -->
 <link
   rel="preload"
@@ -168,6 +175,7 @@ const ogImageAlt = `Preview image for ${title}`;
 <meta name="title" content={title} />
 <meta name="description" content={metaDescription} />
 <meta name="author" content={resolvedAuthor} />
+{keywordsContent && <meta name="keywords" content={keywordsContent} />}
 
 <!-- Open Graph -->
 <meta property="og:type" content={ogType} />

--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -1,0 +1,90 @@
+---
+import { SITE_URL } from '../consts';
+
+interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+const { items = [] } = Astro.props as { items: BreadcrumbItem[] };
+
+const breadcrumbList = items.map((item, index) => ({
+  '@type': 'ListItem',
+  position: index + 1,
+  name: item.label,
+  item: item.href ? new URL(item.href, SITE_URL).toString() : undefined,
+}));
+---
+
+{items.length > 1 && (
+  <nav class="breadcrumbs" aria-label="Breadcrumb">
+    <ol>
+      {items.map((item, index) => {
+        const isLast = index === items.length - 1;
+        return (
+          <li>
+            {item.href && !isLast ? (
+              <a href={item.href}>{item.label}</a>
+            ) : (
+              <span aria-current="page">{item.label}</span>
+            )}
+          </li>
+        );
+      })}
+    </ol>
+    <script is:inline type="application/ld+json">
+      {JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        itemListElement: breadcrumbList,
+      })}
+    </script>
+  </nav>
+)}
+
+<style>
+  .breadcrumbs {
+    margin: 0 0 var(--space-md) 0;
+    font-size: 0.9rem;
+    color: var(--color-text-muted);
+  }
+
+  .breadcrumbs ol {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin: 0;
+    padding: 0;
+  }
+
+  .breadcrumbs li {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .breadcrumbs li::after {
+    content: '/';
+    margin-left: 0.35rem;
+    color: var(--color-text-muted);
+  }
+
+  .breadcrumbs li:last-child::after {
+    content: '';
+  }
+
+  .breadcrumbs a {
+    color: var(--color-link);
+    text-decoration: none;
+  }
+
+  .breadcrumbs a:hover {
+    text-decoration: underline;
+  }
+
+  .breadcrumbs [aria-current='page'] {
+    color: var(--color-text);
+    font-weight: 600;
+  }
+</style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -21,9 +21,12 @@ const { currentPath } = Astro.props;
       />
     </a>
 
-    <nav class="nav-links">
+    <nav class="nav-links" aria-label="Primary">
       <HeaderLink href="/writing/1" currentPath={currentPath} class="nav-item">
         Writing
+      </HeaderLink>
+      <HeaderLink href="/#topics" currentPath={currentPath} class="nav-item">
+        Topics
       </HeaderLink>
       <HeaderLink href="/about" currentPath={currentPath} class="nav-item">
         About

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -43,7 +43,12 @@ const pages = getPageNumbers(currentPage, totalPages);
     {
       currentPage > 1 && (
         <li>
-          <a href={pageHref(currentPage - 1)} class="pagination-link">
+          <a
+            href={pageHref(currentPage - 1)}
+            class="pagination-link"
+            rel="prev"
+            aria-label="Previous page"
+          >
             ← Prev
           </a>
         </li>
@@ -74,7 +79,12 @@ const pages = getPageNumbers(currentPage, totalPages);
     {
       currentPage < totalPages && (
         <li>
-          <a href={pageHref(currentPage + 1)} class="pagination-link">
+          <a
+            href={pageHref(currentPage + 1)}
+            class="pagination-link"
+            rel="next"
+            aria-label="Next page"
+          >
             Next →
           </a>
         </li>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -12,6 +12,8 @@ import ShareButtons from '../components/ShareButtons.astro';
 import TagList from '../components/TagList.astro';
 import SubscribeForm from '../components/SubscribeForm.astro';
 import type { MarkdownHeading } from 'astro';
+import Breadcrumbs from '../components/Breadcrumbs.astro';
+import { titleCase } from '../utils/text';
 
 type Props = {
   post: CollectionEntry<'blog'> & { slug: string };
@@ -29,6 +31,7 @@ const {
   updatedDate,
   heroImage,
   category,
+  categoryNormalized,
   tags = [],
   readingTime,
 } = enrichedPost.data;
@@ -47,6 +50,20 @@ const related = allPosts
 
 // ✅ Canonical URL from clean slug
 const canonicalURL = new URL(`/writing/${slug}/`, SITE_URL).toString();
+
+const breadcrumbItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Writing', href: '/writing/' },
+];
+
+if (categoryNormalized) {
+  breadcrumbItems.push({
+    label: titleCase(categoryNormalized),
+    href: `/writing/category/${encodeURIComponent(categoryNormalized)}`,
+  });
+}
+
+breadcrumbItems.push({ label: title });
 ---
 
 <BaseLayout
@@ -61,6 +78,7 @@ const canonicalURL = new URL(`/writing/${slug}/`, SITE_URL).toString();
 >
   <main>
     <article>
+      <Breadcrumbs items={breadcrumbItems} />
       {
         hero && (
           <div class="hero-image">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,16 +3,19 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import PostList from '../components/PostList.astro';
 import { getCollection } from 'astro:content';
 import { SITE_TITLE } from '../consts';
-import { enrichPost } from '../utils/text'; // ✅ import enrichment
+import { enrichPost } from '../utils/text'; // ✅ import enrichment + helpers
 import SubscribeForm from '../components/SubscribeForm.astro';
 
 const allPosts = await getCollection('blog');
 
+// Enrich all posts once for reuse below
+const enrichedPosts = allPosts.map(enrichPost);
+
 // Pick featured posts, enriched
-const featured = allPosts
+const featured = enrichedPosts
   .filter((post) => post.data.featured)
-  .map(enrichPost) // ✅ ensures slug + readingTime exist
   .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+
 ---
 
 <BaseLayout
@@ -37,8 +40,8 @@ const featured = allPosts
         src="/logos/substack_banner.webp"
         alt="Avoid Boring People newsletter banner"
         class="banner-img"
-        height="120"
-        width="100%"
+        height="400"
+        width="1600"
         fetchpriority="high"
       />
       <span class="tooltip">
@@ -78,9 +81,9 @@ const featured = allPosts
   <section class="featured">
     <h2>As featured in</h2>
     <div class="logo-row">
-      <img src="/logos/hacker_news_logo.webp" alt="Hacker News logo" />
-      <img src="/logos/failory_logo.webp" alt="Failory logo" />
-      <img src="/logos/finextra_logo.webp" alt="Finextra logo" />
+      <img src="/logos/hacker_news_logo.webp" alt="Hacker News logo" loading="lazy" />
+      <img src="/logos/failory_logo.webp" alt="Failory logo" loading="lazy" />
+      <img src="/logos/finextra_logo.webp" alt="Finextra logo" loading="lazy" />
     </div>
   </section>
 </BaseLayout>
@@ -89,6 +92,14 @@ const featured = allPosts
   .banner-wrapper {
     position: relative; /* anchor for absolute tooltip */
     display: inline-block;
+  }
+
+  .banner-img {
+    display: block;
+    width: min(100%, 960px);
+    height: auto;
+    border-radius: 18px;
+    box-shadow: 0 20px 60px rgba(15, 23, 42, 0.16);
   }
 
   .tooltip {

--- a/src/pages/writing/category/[category]/[page].astro
+++ b/src/pages/writing/category/[category]/[page].astro
@@ -1,6 +1,9 @@
 ---
 import BaseLayout from '../../../../layouts/BaseLayout.astro';
-import { getCategoryPostsPaginated, titleCase } from '../../../../utils/text';
+import {
+  getCategoryPostsPaginated,
+  titleCase,
+} from '../../../../utils/text';
 import { SITE_TITLE } from '../../../../consts';
 import type { GetStaticPaths } from 'astro';
 import Pagination from '../../../../components/Pagination.astro';
@@ -17,11 +20,25 @@ const { page, categories = [], activeCategory = '' } = Astro.props;
 const pagedPosts = page.data as any[];
 const currentPage = page.currentPage;
 const totalPages = page.lastPage;
+
+const canonicalBase = `/writing/category/${encodeURIComponent(activeCategory)}`;
+const canonical = currentPage === 1 ? canonicalBase : undefined;
+const relPrev =
+  currentPage > 1
+    ? currentPage === 2
+      ? canonicalBase
+      : `${canonicalBase}/${currentPage - 1}`
+    : undefined;
+const relNext =
+  currentPage < totalPages ? `${canonicalBase}/${currentPage + 1}` : undefined;
 ---
 
 <BaseLayout
   title={`Writing | ${SITE_TITLE}`}
   description={`Essays and posts in category "${titleCase(activeCategory)}"`}
+  canonical={canonical}
+  relPrev={relPrev}
+  relNext={relNext}
 >
   <WritingHeader
     title={`Category: ${titleCase(activeCategory)}`}


### PR DESCRIPTION
## Summary
- remove the homepage topic cluster component and backing configuration so the PR focuses on technical improvements
- keep the breadcrumb, pagination, and metadata enhancements to clarify crawl paths and boost SEO performance

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68d87be62ae0832486f212ce8ac14052