### PR TITLE
Improve accessibility of navigation TOC and share controls

### DIFF
--- a/src/components/HeaderLink.astro
+++ b/src/components/HeaderLink.astro
@@ -24,7 +24,12 @@ const hrefTop = '/' + (href.split('/').filter(Boolean)[0] ?? '');
 const isActive = pathname === href || pathTop === hrefTop;
 ---
 
-<a href={href} class:list={[className, { active: isActive }]} {...props}>
+<a
+  href={href}
+  aria-current={isActive ? 'page' : undefined}
+  class:list={[className, { active: isActive }]}
+  {...props}
+>
   <slot />
 </a>
 

--- a/src/components/ShareButtons.astro
+++ b/src/components/ShareButtons.astro
@@ -57,30 +57,47 @@ const encodedURL = encodeURIComponent(url);
 
   <!-- Mobile dropdown -->
   <div class="mobile-only dropdown">
-    <button type="button" class="dropdown-toggle">
+    <button
+      type="button"
+      id="share-toggle"
+      class="dropdown-toggle"
+      aria-haspopup="menu"
+      aria-expanded="false"
+      aria-controls="share-menu"
+    >
       <Share2 class="icon" /> Share
     </button>
-    <div class="dropdown-menu">
+    <div
+      id="share-menu"
+      class="dropdown-menu"
+      role="menu"
+      aria-labelledby="share-toggle"
+      hidden
+    >
       <a
         href={`https://www.threads.net/intent/post?text=${encodedTitle}%20${encodedURL}`}
         target="_blank"
         rel="noopener noreferrer"
+        role="menuitem"
         data-share="Threads">Threads</a
       >
       <a
         href={`https://twitter.com/intent/tweet?text=${encodedTitle}&url=${encodedURL}`}
         target="_blank"
         rel="noopener noreferrer"
+        role="menuitem"
         data-share="Twitter">Twitter</a
       >
       <a
         href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodedURL}`}
         target="_blank"
         rel="noopener noreferrer"
+        role="menuitem"
         data-share="LinkedIn">LinkedIn</a
       >
       <a
         href={`mailto:?subject=${encodedTitle}&body=${encodedURL}`}
+        role="menuitem"
         data-share="Email">Email</a
       >
     </div>
@@ -103,11 +120,34 @@ const encodedURL = encodeURIComponent(url);
     const toggle = document.querySelector('.dropdown-toggle');
     const menu = document.querySelector('.dropdown-menu');
 
+    const closeMenu = (returnFocus = true) => {
+      if (!toggle || !menu) return;
+      menu.classList.remove('open');
+      menu.hidden = true;
+      toggle.setAttribute('aria-expanded', 'false');
+      if (returnFocus) {
+        toggle.focus();
+      }
+    };
+
+    const openMenu = () => {
+      if (!toggle || !menu) return;
+      menu.classList.add('open');
+      menu.hidden = false;
+      toggle.setAttribute('aria-expanded', 'true');
+      const firstItem = menu.querySelector('[role="menuitem"]');
+      if (firstItem instanceof HTMLElement) {
+        firstItem.focus();
+      }
+    };
+
     // Track clicks on all share links
     document.querySelectorAll('[data-share]').forEach((el) => {
       el.addEventListener('click', () => {
         trackShare(el.dataset.share);
-        if (menu?.classList.contains('open')) menu.classList.remove('open');
+        if (menu?.classList.contains('open')) {
+          closeMenu(false);
+        }
       });
     });
 
@@ -115,20 +155,26 @@ const encodedURL = encodeURIComponent(url);
     if (toggle && menu) {
       toggle.addEventListener('click', (e) => {
         e.stopPropagation(); // prevent immediate close
-        menu.classList.toggle('open');
+        if (menu.classList.contains('open')) {
+          closeMenu(false);
+        } else {
+          openMenu();
+        }
+      });
+
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && menu.classList.contains('open')) {
+          closeMenu();
+        }
+      });
+
+      // Close dropdown when clicking outside
+      document.addEventListener('click', (e) => {
+        if (menu.classList.contains('open') && !dropdown?.contains(e.target)) {
+          closeMenu();
+        }
       });
     }
-
-    // Close dropdown when clicking outside
-    document.addEventListener('click', (e) => {
-      if (
-        menu?.classList.contains('open') &&
-        dropdown &&
-        !dropdown.contains(e.target)
-      ) {
-        menu.classList.remove('open');
-      }
-    });
   });
 </script>
 

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -12,7 +12,9 @@ const { headings = [] } = Astro.props as Props;
 <aside class="toc-desktop">
   <!-- collapsed: mini segments -->
   <div class="toc-mini">
-    {headings.map((h) => <div class="toc-bar-segment" data-id={h.slug} />)}
+    {headings.map((h) => (
+      <div class="toc-bar-segment" data-id={h.slug} aria-hidden="true" />
+    ))}
   </div>
 
   <!-- expanded: flyout -->
@@ -31,7 +33,14 @@ const { headings = [] } = Astro.props as Props;
 
 <!-- ================= MOBILE ================= -->
 <div class="toc-mobile">
-  <button id="toc-toggle" class="toc-button">☰ Contents</button>
+  <button
+    id="toc-toggle"
+    class="toc-button"
+    aria-expanded="false"
+    aria-controls="toc-drawer"
+  >
+    ☰ Contents
+  </button>
   <div id="toc-drawer" class="toc-drawer">
     <ul>
       {
@@ -271,12 +280,19 @@ const { headings = [] } = Astro.props as Props;
           : null);
 
       if (target) {
-        target.scrollIntoView({ behavior: 'smooth' });
+        const prefersReducedMotion = window.matchMedia
+          ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+          : false;
+        target.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth' });
       }
 
       // Close mobile drawer/backdrop if open
-      document.getElementById('toc-drawer')?.classList.remove('open');
-      document.getElementById('toc-backdrop')?.classList.remove('visible');
+      const drawerEl = document.getElementById('toc-drawer');
+      const backdropEl = document.getElementById('toc-backdrop');
+      const toggleBtn = document.getElementById('toc-toggle');
+      drawerEl?.classList.remove('open');
+      backdropEl?.classList.remove('visible');
+      toggleBtn?.setAttribute('aria-expanded', 'false');
     });
   });
 
@@ -286,14 +302,23 @@ const { headings = [] } = Astro.props as Props;
   const backdrop = document.getElementById('toc-backdrop');
 
   if (btn && drawer && backdrop) {
+    const updateButtonState = () => {
+      const expanded = drawer.classList.contains('open');
+      btn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    };
+
+    updateButtonState();
+
     btn.addEventListener('click', () => {
       drawer.classList.toggle('open');
       backdrop.classList.toggle('visible');
+      updateButtonState();
     });
 
     backdrop.addEventListener('click', () => {
       drawer.classList.remove('open');
       backdrop.classList.remove('visible');
+      updateButtonState();
     });
   }
 </script>


### PR DESCRIPTION
## Summary
- add aria attributes to the table of contents toggle, hide decorative bars, and respect reduced motion during scrolling
- make the share dropdown expose its menu semantics, manage focus, and close on escape/outside clicks
- expose active header links with aria-current so screen readers announce the current section

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d92fcfdc1483248bb46421549ea792