### PR TITLE
Fix pagination URLs to avoid redirects

### DIFF
--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -1,4 +1,6 @@
 ---
+import { buildPaginationHref } from '../utils/pagination.ts';
+
 interface Props {
   currentPage: number;
   totalPages: number;
@@ -7,15 +9,7 @@ interface Props {
 
 const { currentPage, totalPages, activeCategory = '' } = Astro.props;
 
-const pageHref = (page: number) => {
-  if (activeCategory) {
-    return page === 1
-      ? `/writing/category/${encodeURIComponent(activeCategory)}`
-      : `/writing/category/${encodeURIComponent(activeCategory)}/${page}`;
-  } else {
-    return page === 1 ? `/writing` : `/writing/${page}`;
-  }
-};
+const pageHref = (page: number) => buildPaginationHref(page, activeCategory);
 
 // Ellipses pagination helper
 function getPageNumbers(current: number, total: number): (number | string)[] {

--- a/src/pages/writing/[page].astro
+++ b/src/pages/writing/[page].astro
@@ -7,6 +7,7 @@ import Pagination from '../../components/Pagination.astro';
 import Filters from '../../components/Filters.astro';
 import PostList from '../../components/PostList.astro';
 import WritingHeader from '../../components/WritingHeader.astro';
+import { buildPaginationHref } from '../../utils/pagination.ts';
 
 export const getStaticPaths = (async ({ paginate }) => {
   const { pages, categories } = await getAllPostsPaginated(paginate, 8);
@@ -26,15 +27,11 @@ const currentPage = page.currentPage;
 const totalPages = page.lastPage;
 
 const activeCategory = ''; // "All" page
-const canonical = currentPage === 1 ? '/writing/' : undefined;
+const canonical = currentPage === 1 ? buildPaginationHref(1) : undefined;
 const relPrev =
-  currentPage > 1
-    ? currentPage === 2
-      ? '/writing/'
-      : `/writing/${currentPage - 1}`
-    : undefined;
+  currentPage > 1 ? buildPaginationHref(currentPage - 1) : undefined;
 const relNext =
-  currentPage < totalPages ? `/writing/${currentPage + 1}` : undefined;
+  currentPage < totalPages ? buildPaginationHref(currentPage + 1) : undefined;
 ---
 
 <BaseLayout

--- a/src/pages/writing/category/[category]/[page].astro
+++ b/src/pages/writing/category/[category]/[page].astro
@@ -10,6 +10,7 @@ import Pagination from '../../../../components/Pagination.astro';
 import Filters from '../../../../components/Filters.astro';
 import PostList from '../../../../components/PostList.astro';
 import WritingHeader from '../../../../components/WritingHeader.astro';
+import { buildPaginationHref } from '../../../../utils/pagination.ts';
 
 export const getStaticPaths = (async ({ paginate }) => {
   return await getCategoryPostsPaginated(paginate, 8);
@@ -21,16 +22,14 @@ const pagedPosts = page.data as any[];
 const currentPage = page.currentPage;
 const totalPages = page.lastPage;
 
-const canonicalBase = `/writing/category/${encodeURIComponent(activeCategory)}`;
-const canonical = currentPage === 1 ? canonicalBase : undefined;
+const canonical =
+  currentPage === 1 ? buildPaginationHref(1, activeCategory) : undefined;
 const relPrev =
-  currentPage > 1
-    ? currentPage === 2
-      ? canonicalBase
-      : `${canonicalBase}/${currentPage - 1}`
-    : undefined;
+  currentPage > 1 ? buildPaginationHref(currentPage - 1, activeCategory) : undefined;
 const relNext =
-  currentPage < totalPages ? `${canonicalBase}/${currentPage + 1}` : undefined;
+  currentPage < totalPages
+    ? buildPaginationHref(currentPage + 1, activeCategory)
+    : undefined;
 ---
 
 <BaseLayout

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,0 +1,9 @@
+export function buildPaginationHref(page: number, activeCategory?: string) {
+  const normalizedPage = Math.max(1, Math.trunc(page));
+
+  if (activeCategory) {
+    return `/writing/category/${encodeURIComponent(activeCategory)}/${normalizedPage}`;
+  }
+
+  return `/writing/${normalizedPage}`;
+}

--- a/tests/run-tests.ts
+++ b/tests/run-tests.ts
@@ -13,6 +13,7 @@ import {
 } from '../src/utils/text.ts';
 import { extractHeadings } from '../src/utils/toc.ts';
 import { normalizeHeroImage } from '../src/utils/hero.ts';
+import { buildPaginationHref } from '../src/utils/pagination.ts';
 
 process.on('uncaughtException', (error) => {
   console.error('❌ Uncaught exception', error);
@@ -175,6 +176,18 @@ function testComputeCleanSlug() {
 function testNormalizeQuery() {
   assert.equal(normalizeQuery('   Venture   Deals  '), 'venture deals');
   assert.equal(normalizeQuery('\n\t  MIXED Case  '), 'mixed case');
+}
+
+function testBuildPaginationHref() {
+  assert.equal(buildPaginationHref(1), '/writing/1');
+  assert.equal(buildPaginationHref(2), '/writing/2');
+  assert.equal(buildPaginationHref(1, 'finance'), '/writing/category/finance/1');
+  assert.equal(
+    buildPaginationHref(5, 'markets & money'),
+    '/writing/category/markets%20%26%20money/5',
+  );
+  assert.equal(buildPaginationHref(0, 'finance'), '/writing/category/finance/1');
+  assert.equal(buildPaginationHref(3.7), '/writing/3');
 }
 
 function testTitleCase() {
@@ -610,6 +623,7 @@ async function run() {
     testSearchPosts();
     testComputeCleanSlug();
     testNormalizeQuery();
+    testBuildPaginationHref();
     testTitleCase();
     testNormalizeCategory();
     testEnrichPost();


### PR DESCRIPTION
## Summary
- add a shared pagination URL helper that always links directly to the canonical page
- update pagination components and prev/next metadata to use the canonical URLs instead of redirect targets
- add regression tests covering the pagination URL helper, including encoding behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d9301f151c83248f2c241e8cbfdeb8