### PR TITLE
Fix type errors in metadata and test utilities

### DIFF
--- a/scripts/automation/publish0x_runner.js
+++ b/scripts/automation/publish0x_runner.js
@@ -33,7 +33,7 @@ async function autopostToPublish0x(post) {
   await page.fill('input[name="postTitle"]', post.title);
 
   // Switch into TinyMCE iframe for content
-  const frame = await page.frameLocator('#postText_ifr');
+  const frame = page.frameLocator('#postText_ifr');
   await frame.locator('body#tinymce').click();
   await frame.locator('body#tinymce').fill(post.content);
 

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -8,6 +8,41 @@ import {
   SITE_AUTHOR,
 } from "../consts";
 
+type OrganizationSchema = {
+  "@context": "https://schema.org";
+  "@type": "Organization";
+  url: string;
+  logo: string;
+  name: string;
+};
+
+type ArticleSchema = {
+  "@context": "https://schema.org";
+  "@type": "BlogPosting";
+  headline: string;
+  description: string;
+  image: string[];
+  datePublished: string;
+  dateModified: string;
+  author: {
+    "@type": string;
+    name: string;
+  };
+  publisher: {
+    "@type": string;
+    name: string;
+    logo: {
+      "@type": string;
+      url: string;
+    };
+  };
+  mainEntityOfPage: {
+    "@type": string;
+    "@id": string | undefined;
+  };
+  keywords?: string;
+};
+
 const {
   title,
   description,
@@ -83,7 +118,7 @@ const keywordsContent =
 const orgLogo = new URL("/logos/substack_logo.webp", SITE_URL).toString();
 
 // ✅ Organization structured data
-const orgSchema = {
+const orgSchema: OrganizationSchema = {
   "@context": "https://schema.org",
   "@type": "Organization",
   url: SITE_URL,
@@ -92,7 +127,7 @@ const orgSchema = {
 };
 
 // ✅ Article structured data (only if pubDate provided → means it's a blog post)
-let articleSchema;
+let articleSchema: ArticleSchema | undefined;
 if (pubDate) {
   articleSchema = {
     "@context": "https://schema.org",
@@ -123,7 +158,10 @@ if (pubDate) {
 
 // ✅ Merge schemas into one JSON-LD array
 if (articleSchema && normalizedTags.length > 0) {
-  articleSchema.keywords = normalizedTags.join(", ");
+  articleSchema = {
+    ...articleSchema,
+    keywords: normalizedTags.join(", "),
+  };
 }
 
 const structuredData = articleSchema ? [orgSchema, articleSchema] : [orgSchema];
@@ -211,7 +249,7 @@ const ogImageAlt = `Preview image for ${title}`;
 )}
 {ogType === "article" &&
   normalizedTags.map((tag) => (
-    <meta property="article:tag" content={tag} key={tag} />
+    <meta property="article:tag" content={tag} />
   ))}
 
 <!-- Twitter -->

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -51,7 +51,12 @@ const related = allPosts
 // ✅ Canonical URL from clean slug
 const canonicalURL = new URL(`/writing/${slug}/`, SITE_URL).toString();
 
-const breadcrumbItems = [
+type BreadcrumbItem = {
+  label: string;
+  href?: string;
+};
+
+const breadcrumbItems: BreadcrumbItem[] = [
   { label: 'Home', href: '/' },
   { label: 'Writing', href: '/writing/' },
 ];

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -21,9 +21,9 @@ export type PaginateFn = <T>(
   options: { pageSize: number; params?: Record<string, any> },
 ) => Array<any>;
 
-type GetCollectionFn = <CollectionName extends string = string>(
-  collection: CollectionName,
-) => Promise<CollectionEntry<CollectionName>[]>;
+type GetCollectionFn = (
+  collection: 'blog',
+) => Promise<CollectionEntry<'blog'>[]>;
 
 /**
  * Convert a string to Title Case.

--- a/tests/register-loaders.mjs
+++ b/tests/register-loaders.mjs
@@ -1,3 +1,3 @@
 import { register } from 'node:module';
 
-await register('./astro-content-loader.mjs', import.meta.url);
+register('./astro-content-loader.mjs', import.meta.url);

--- a/tests/run-tests.ts
+++ b/tests/run-tests.ts
@@ -457,11 +457,13 @@ async function withMockGetCollection(
   callback: () => Promise<void> | void,
 ) {
   __setMockGetCollectionImplementation(async () => posts as any);
+  setGetCollectionImplementation(async () => posts as any);
 
   try {
     await callback();
   } finally {
     __setMockGetCollectionImplementation(null);
+    setGetCollectionImplementation(null);
   }
 }
 

--- a/tests/types/astro-content.d.ts
+++ b/tests/types/astro-content.d.ts
@@ -1,0 +1,5 @@
+declare module 'astro:content' {
+  export function __setMockGetCollectionImplementation(
+    replacement: ((collection: string) => Promise<any[]>) | null,
+  ): void;
+}


### PR DESCRIPTION
## Summary
- type the structured data metadata in the head component and drop unsupported meta attributes
- relax breadcrumb typings and helper utilities to accept blog collection mocks while cleaning up the Publish0x runner
- ensure the astro:content mock is declared for TypeScript and wired into the test harness

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68dbdf9dc72c8324844ce3c689c59a1f