### PR TITLE
Point automation workflows to scripts/automation/requirements.txt

### DIFF
--- a/.github/workflows/autopost.yml
+++ b/.github/workflows/autopost.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
+          python -m pip install -r scripts/automation/requirements.txt
 
       - name: Add random delay
         run: |

--- a/.github/workflows/medium-prep.yml
+++ b/.github/workflows/medium-prep.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
+          pip install -r scripts/automation/requirements.txt
 
       - name: Generate Medium summary
         run: |


### PR DESCRIPTION
### Motivation
- The GitHub Actions failed because the workflows attempted to install a missing root-level `requirements.txt` instead of the existing automation requirements file.

### Description
- Update `.github/workflows/autopost.yml` and `.github/workflows/medium-prep.yml` to install dependencies from `scripts/automation/requirements.txt`.

### Testing
- No automated tests were run because this change only modifies workflow files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69723c863af88324ae894a8a2e3f7e5a)