### PR TITLE
Update robots.txt for SEO/AEO crawler access and private path blocking

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,22 +1,74 @@
-# Allow all search and AI crawlers
+# robots.txt for leonlins.com
+# Goal: maximize SEO + AEO visibility while protecting private and non-public areas.
+
+# Default policy for all crawlers:
+# - Allow public content for indexing/citation.
+# - Block private, admin, login, draft, and staging paths.
 User-agent: *
 Allow: /
+Disallow: /admin/
+Disallow: /login/
+Disallow: /drafts/
+Disallow: /private/
+Disallow: /staging/
 
-# Explicitly allow AI crawlers
+# Explicit allow for major search crawlers.
+User-agent: Googlebot
+Allow: /
+Disallow: /admin/
+Disallow: /login/
+Disallow: /drafts/
+Disallow: /private/
+Disallow: /staging/
+
+User-agent: Bingbot
+Allow: /
+Disallow: /admin/
+Disallow: /login/
+Disallow: /drafts/
+Disallow: /private/
+Disallow: /staging/
+
+# Explicit allow for AI crawlers and dataset crawlers commonly used by LLM systems.
 User-agent: GPTBot
 Allow: /
-
-User-agent: Google-Extended
-Allow: /
-
-User-agent: PerplexityBot
-Allow: /
+Disallow: /admin/
+Disallow: /login/
+Disallow: /drafts/
+Disallow: /private/
+Disallow: /staging/
 
 User-agent: ClaudeBot
 Allow: /
+Disallow: /admin/
+Disallow: /login/
+Disallow: /drafts/
+Disallow: /private/
+Disallow: /staging/
 
-User-agent: anthropic-ai
+User-agent: PerplexityBot
 Allow: /
+Disallow: /admin/
+Disallow: /login/
+Disallow: /drafts/
+Disallow: /private/
+Disallow: /staging/
 
-# Sitemap for faster discovery
+User-agent: Google-Extended
+Allow: /
+Disallow: /admin/
+Disallow: /login/
+Disallow: /drafts/
+Disallow: /private/
+Disallow: /staging/
+
+User-agent: CCBot
+Allow: /
+Disallow: /admin/
+Disallow: /login/
+Disallow: /drafts/
+Disallow: /private/
+Disallow: /staging/
+
+# Sitemap helps search engines and AI crawlers discover canonical URLs faster.
 Sitemap: https://leonlins.com/sitemap-index.xml


### PR DESCRIPTION
### Motivation
- Improve search engine visibility and AI Engine Optimization (AEO) for public writing while explicitly protecting non-public areas from indexing and citation.
- Provide clear, maintainable rules and a sitemap reference so search engines and AI crawlers can discover canonical content quickly.

### Description
- Replaced `public/robots.txt` with a production-ready policy that allows public content while disallowing `/admin/`, `/login/`, `/drafts/`, `/private/`, and `/staging/`.
- Added explicit `User-agent` sections for `Googlebot`, `Bingbot`, `GPTBot`, `ClaudeBot`, `PerplexityBot`, `Google-Extended`, and `CCBot` mirroring the default allow/block rules.
- Included explanatory comments above each section describing intent for SEO/AEO and maintainability.
- Added a `Sitemap` reference to `https://leonlins.com/sitemap-index.xml` to speed discovery.

### Testing
- Verified the file contents with `cat public/robots.txt` and `nl -ba public/robots.txt`, which show the expected rules (succeeded).
- Inspected the changes with `git diff -- public/robots.txt` to confirm the modifications are limited to the robots configuration (succeeded).
- No project build or automated test suite was required for this text-only configuration update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c53cd8fe748327895eac458fdde9b7)