### PR TITLE
Enhance SEO with structured data, sitemap, and robots.txt improvements

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,16 +6,68 @@ import remarkFootnotes from 'remark-footnotes';
 import { SITE_URL } from './src/consts.ts';
 import preact from '@astrojs/preact';
 import { visualizer } from 'rollup-plugin-visualizer';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Build a map of blog post URL pathname → ISO lastmod date.
+ * Reads frontmatter from each index.md at build time to avoid using new Date().
+ */
+function buildBlogLastmodMap() {
+  const blogDir = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    'src/content/blog',
+  );
+  /** @type {Record<string, string>} */
+  const map = {};
+  try {
+    const entries = fs.readdirSync(blogDir);
+    for (const entry of entries) {
+      const mdPath = path.join(blogDir, entry, 'index.md');
+      if (!fs.existsSync(mdPath)) continue;
+      const content = fs.readFileSync(mdPath, 'utf-8');
+      // Parse updatedDate first, fall back to pubDate
+      const updatedMatch = content.match(/^updatedDate:\s*(\S+)/m);
+      const pubMatch = content.match(/^pubDate:\s*(\S+)/m);
+      const slugOverride = content.match(/^slug:\s*(\S+)/m);
+      const dateStr = updatedMatch?.[1] ?? pubMatch?.[1];
+      if (!dateStr) continue;
+      const slug = slugOverride
+        ? slugOverride[1]
+        : entry.replace(/^\d{4}_\d{2}_\d{2}_/, '');
+      map[`/writing/${slug}/`] = new Date(dateStr).toISOString();
+    }
+  } catch {
+    // non-fatal: fall through to static fallback
+  }
+  return map;
+}
+
+const blogLastmod = buildBlogLastmodMap();
+// Stable fallback date for non-blog static pages (site launch / last major update)
+const STATIC_LASTMOD = '2025-01-01T00:00:00.000Z';
 
 export default defineConfig({
   site: SITE_URL,
   integrations: [
     sitemap({
-      // Simplified: SitemapItem has no .data, so just return lastmod = now
+      filter(page) {
+        const pathname = new URL(page).pathname;
+        // Exclude search (noindex), tokens (noindex), and api endpoints
+        return (
+          !pathname.startsWith('/api/') &&
+          pathname !== '/writing/search/' &&
+          pathname !== '/writing/search' &&
+          pathname !== '/tokens/' &&
+          pathname !== '/tokens'
+        );
+      },
       serialize(item) {
+        const pathname = new URL(item.url).pathname;
         return {
           ...item,
-          lastmod: new Date().toISOString(),
+          lastmod: blogLastmod[pathname] ?? STATIC_LASTMOD,
         };
       },
     }),

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,7 +3,7 @@
 
 # Default policy for all crawlers:
 # - Allow public content for indexing/citation.
-# - Block private, admin, login, draft, and staging paths.
+# - Block private, admin, login, draft, staging, and build artifact paths.
 User-agent: *
 Allow: /
 Disallow: /admin/
@@ -11,6 +11,8 @@ Disallow: /login/
 Disallow: /drafts/
 Disallow: /private/
 Disallow: /staging/
+Disallow: /api/
+Disallow: /stats.html
 
 # Explicit allow for major search crawlers.
 User-agent: Googlebot
@@ -20,6 +22,8 @@ Disallow: /login/
 Disallow: /drafts/
 Disallow: /private/
 Disallow: /staging/
+Disallow: /api/
+Disallow: /stats.html
 
 User-agent: Bingbot
 Allow: /
@@ -28,6 +32,8 @@ Disallow: /login/
 Disallow: /drafts/
 Disallow: /private/
 Disallow: /staging/
+Disallow: /api/
+Disallow: /stats.html
 
 # Explicit allow for AI crawlers and dataset crawlers commonly used by LLM systems.
 User-agent: GPTBot
@@ -37,6 +43,8 @@ Disallow: /login/
 Disallow: /drafts/
 Disallow: /private/
 Disallow: /staging/
+Disallow: /api/
+Disallow: /stats.html
 
 User-agent: ClaudeBot
 Allow: /
@@ -45,6 +53,8 @@ Disallow: /login/
 Disallow: /drafts/
 Disallow: /private/
 Disallow: /staging/
+Disallow: /api/
+Disallow: /stats.html
 
 User-agent: PerplexityBot
 Allow: /
@@ -53,6 +63,8 @@ Disallow: /login/
 Disallow: /drafts/
 Disallow: /private/
 Disallow: /staging/
+Disallow: /api/
+Disallow: /stats.html
 
 User-agent: Google-Extended
 Allow: /
@@ -61,6 +73,8 @@ Disallow: /login/
 Disallow: /drafts/
 Disallow: /private/
 Disallow: /staging/
+Disallow: /api/
+Disallow: /stats.html
 
 User-agent: CCBot
 Allow: /
@@ -69,6 +83,8 @@ Disallow: /login/
 Disallow: /drafts/
 Disallow: /private/
 Disallow: /staging/
+Disallow: /api/
+Disallow: /stats.html
 
 # Sitemap helps search engines and AI crawlers discover canonical URLs faster.
 Sitemap: https://leonlins.com/sitemap-index.xml

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -6,6 +6,9 @@ import {
   SITE_URL,
   SITE_OG_IMAGE,
   SITE_AUTHOR,
+  SITE_AUTHOR_URL,
+  SITE_AUTHOR_SAME_AS,
+  SITE_ORG_SAME_AS,
 } from "../consts";
 
 const {
@@ -20,6 +23,8 @@ const {
   canonical,
   relPrev,
   relNext,
+  includePerson = false,
+  noindex = false,
 } = Astro.props as {
   title: string;
   description?: string;
@@ -32,6 +37,8 @@ const {
   canonical?: string;
   relPrev?: string;
   relNext?: string;
+  includePerson?: boolean;
+  noindex?: boolean;
 };
 
 const resolveAbsoluteURL = (maybeRelative?: string) => {
@@ -82,14 +89,62 @@ const keywordsContent =
 // ✅ Absolute URL for organization logo
 const orgLogo = new URL("/logos/substack_logo.webp", SITE_URL).toString();
 
-// ✅ Organization structured data
+// ✅ Organization structured data (improved: description + sameAs)
 const orgSchema = {
   "@context": "https://schema.org",
   "@type": "Organization",
+  "@id": `${SITE_URL}#organization`,
   url: SITE_URL,
-  logo: orgLogo,
   name: SITE_TITLE,
+  description: SITE_DESCRIPTION,
+  logo: {
+    "@type": "ImageObject",
+    url: orgLogo,
+  },
+  sameAs: SITE_ORG_SAME_AS,
 };
+
+// ✅ WebSite schema with SearchAction (always included)
+const websiteSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "@id": `${SITE_URL}#website`,
+  url: SITE_URL,
+  name: SITE_TITLE,
+  description: SITE_DESCRIPTION,
+  publisher: { "@id": `${SITE_URL}#organization` },
+  potentialAction: {
+    "@type": "SearchAction",
+    target: {
+      "@type": "EntryPoint",
+      urlTemplate: `${SITE_URL}writing/search?q={search_term_string}`,
+    },
+    "query-input": "required name=search_term_string",
+  },
+};
+
+// ✅ Person schema (included on About page via includePerson prop)
+const personSchema = includePerson
+  ? {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "@id": `${SITE_URL}#person`,
+      name: SITE_AUTHOR,
+      url: SITE_AUTHOR_URL,
+      jobTitle: "Writer, Investor, and Advisor",
+      worksFor: { "@id": `${SITE_URL}#organization` },
+      knowsAbout: [
+        "Finance",
+        "Technology",
+        "Investing",
+        "Decision-Making",
+        "Investment Banking",
+        "Startups",
+        "Venture Capital",
+      ],
+      sameAs: SITE_AUTHOR_SAME_AS,
+    }
+  : null;
 
 // ✅ Article structured data (only if pubDate provided → means it's a blog post)
 let articleSchema;
@@ -105,19 +160,14 @@ if (pubDate) {
     author: {
       "@type": "Person",
       name: resolvedAuthor,
+      url: SITE_AUTHOR_URL,
     },
-    publisher: {
-      "@type": "Organization",
-      name: SITE_TITLE,
-      logo: {
-        "@type": "ImageObject",
-        url: orgLogo,
-      },
-    },
+    publisher: { "@id": `${SITE_URL}#organization` },
     mainEntityOfPage: {
       "@type": "WebPage",
       "@id": canonicalURL,
     },
+    isPartOf: { "@id": `${SITE_URL}#website` },
   };
 }
 
@@ -126,7 +176,12 @@ if (articleSchema && normalizedTags.length > 0) {
   articleSchema.keywords = normalizedTags.join(", ");
 }
 
-const structuredData = articleSchema ? [orgSchema, articleSchema] : [orgSchema];
+const structuredData = [
+  orgSchema,
+  websiteSchema,
+  ...(articleSchema ? [articleSchema] : []),
+  ...(personSchema ? [personSchema] : []),
+];
 const ogImageAlt = `Preview image for ${title}`;
 ---
 
@@ -190,6 +245,7 @@ const ogImageAlt = `Preview image for ${title}`;
 <meta name="description" content={metaDescription} />
 <meta name="author" content={resolvedAuthor} />
 {keywordsContent && <meta name="keywords" content={keywordsContent} />}
+{noindex && <meta name="robots" content="noindex, follow" />}
 
 <!-- Open Graph -->
 <meta property="og:type" content={ogType} />

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -6,6 +6,19 @@ export const SITE_DESCRIPTION =
   'Writing on finance, tech, and other ideas by Leon Lin';
 export const SITE_URL = 'https://leonlins.com/';
 export const SITE_AUTHOR = 'Leon Lin';
+export const SITE_AUTHOR_URL = 'https://leonlins.com/about/';
+
+// Social profiles for structured data sameAs
+export const SITE_AUTHOR_SAME_AS = [
+  'https://twitter.com/leonlinsx',
+  'https://github.com/leonlinsx',
+  'https://avoidboringpeople.substack.com',
+];
+
+export const SITE_ORG_SAME_AS = [
+  'https://twitter.com/leonlinsx',
+  'https://avoidboringpeople.substack.com',
+];
 
 // ✅ Default Open Graph image (used if no heroImage is set in frontmatter)
 // Place this file in `public/logos/` so it's accessible at /logos/substack_logo.png

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,6 +15,8 @@ const {
   canonical,
   relPrev,
   relNext,
+  includePerson,
+  noindex,
 } = Astro.props;
 const GA_ID = import.meta.env.PUBLIC_GA_ID;
 const isProd = import.meta.env.PROD;
@@ -34,6 +36,8 @@ const isProd = import.meta.env.PROD;
       canonical={canonical}
       relPrev={relPrev}
       relNext={relNext}
+      includePerson={includePerson}
+      noindex={noindex}
     />
 
     {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -6,6 +6,7 @@ import { SITE_TITLE } from '../consts';
 <BaseLayout
   title={`About Me | ${SITE_TITLE}`}
   description="Learn more about Leon Lin — background, beliefs, interests, and how to connect."
+  includePerson={true}
 >
   <h1>About Me</h1>
   <p class="subtext">Who I am, what I write about, and how to connect.</p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,7 +19,7 @@ const featured = enrichedPosts
 ---
 
 <BaseLayout
-  title={`Home | ${SITE_TITLE}`}
+  title={SITE_TITLE}
   description="Writing on finance, tech, and other ideas by Leon Lin"
 >
   <head>

--- a/src/pages/writing/search.astro
+++ b/src/pages/writing/search.astro
@@ -25,6 +25,7 @@ const visibleIds = new Set(filteredPosts.map((post) => post.id));
 <BaseLayout
   title={`Search | ${SITE_TITLE}`}
   description={`Search results for "${q}"`}
+  noindex={true}
 >
   <div class="search-header">
     <h1>Search Results</h1>


### PR DESCRIPTION
## Summary
This PR significantly improves SEO and search engine discoverability by enhancing structured data markup, implementing dynamic sitemap generation with accurate lastmod dates, and refining robots.txt policies for better crawler management.

## Key Changes

### Structured Data Enhancements (BaseHead.astro)
- **Organization schema**: Added `@id`, description, improved logo structure, and `sameAs` social profiles
- **WebSite schema**: New schema with SearchAction for site search functionality
- **Person schema**: Conditional Person schema for About page (via `includePerson` prop) with jobTitle, expertise areas, and social profiles
- **Article schema**: Improved with author URL and references to organization/website via `@id` instead of inline duplication
- **Meta tags**: Added `noindex` support via new `noindex` prop for pages that shouldn't be indexed (search, tokens)

### Sitemap Improvements (astro.config.mjs)
- **Dynamic lastmod dates**: Implemented `buildBlogLastmodMap()` function that parses blog post frontmatter at build time
- **Smart date selection**: Uses `updatedDate` if available, falls back to `pubDate`
- **Slug handling**: Respects `slug` frontmatter override, otherwise derives from directory name
- **Sitemap filtering**: Excludes API endpoints, search page, and tokens page from sitemap
- **Static fallback**: Uses stable `STATIC_LASTMOD` date for non-blog pages

### Robots.txt Refinements (public/robots.txt)
- **API blocking**: Added `/api/` to disallow list across all user agents
- **Build artifacts**: Added `/stats.html` to disallow list
- **Consistent policies**: Applied same restrictions to Googlebot, Bingbot, and AI crawlers (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, CCBot)

### Configuration Updates (src/consts.ts)
- **Author URL**: Added `SITE_AUTHOR_URL` constant
- **Social profiles**: New `SITE_AUTHOR_SAME_AS` array for Person schema
- **Organization profiles**: New `SITE_ORG_SAME_AS` array for Organization schema

### Layout & Page Updates
- **BaseLayout.astro**: Passes through `includePerson` and `noindex` props to BaseHead
- **about.astro**: Enables Person schema with `includePerson={true}`
- **search.astro**: Marks search page as `noindex={true}`
- **index.astro**: Simplified home page title (removed "Home |" prefix)

## Notable Implementation Details
- Structured data uses `@id` references to avoid duplication and improve semantic relationships
- Blog post dates are read at build time from frontmatter, ensuring accurate lastmod without relying on file system timestamps
- Conditional schema generation (Person, Article) keeps JSON-LD clean and relevant
- Robots.txt policies are now consistent across all crawler types for maintainability

https://claude.ai/code/session_01JQDQzbKHVxdFCSfvzrEMSQ