### PR TITLE
Normalize pathnames, simplify structured data, and fix sitemap URLs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -47,6 +47,10 @@ function buildBlogLastmodMap() {
 const blogLastmod = buildBlogLastmodMap();
 // Stable fallback date for non-blog static pages (site launch / last major update)
 const STATIC_LASTMOD = '2025-01-01T00:00:00.000Z';
+const normalizePathname = (pathname) => {
+  if (!pathname || pathname === '/') return '/';
+  return pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+};
 
 export default defineConfig({
   site: SITE_URL,
@@ -64,9 +68,12 @@ export default defineConfig({
         );
       },
       serialize(item) {
-        const pathname = new URL(item.url).pathname;
+        const url = new URL(item.url);
+        const pathname = normalizePathname(url.pathname);
+        url.pathname = pathname;
         return {
           ...item,
+          url: url.toString(),
           lastmod: blogLastmod[pathname] ?? STATIC_LASTMOD,
         };
       },

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -8,7 +8,6 @@ import {
   SITE_AUTHOR,
   SITE_AUTHOR_URL,
   SITE_AUTHOR_SAME_AS,
-  SITE_ORG_SAME_AS,
 } from "../consts";
 
 const {
@@ -23,7 +22,6 @@ const {
   canonical,
   relPrev,
   relNext,
-  includePerson = false,
   noindex = false,
 } = Astro.props as {
   title: string;
@@ -37,22 +35,33 @@ const {
   canonical?: string;
   relPrev?: string;
   relNext?: string;
-  includePerson?: boolean;
   noindex?: boolean;
+};
+
+const normalizePathname = (pathname: string) => {
+  if (!pathname || pathname === '/') return '/';
+  return pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
 };
 
 const resolveAbsoluteURL = (maybeRelative?: string) => {
   if (!maybeRelative) return undefined;
-  if (maybeRelative.startsWith("http")) return maybeRelative;
+  if (maybeRelative.startsWith("http")) {
+    const parsed = new URL(maybeRelative);
+    parsed.pathname = normalizePathname(parsed.pathname);
+    return parsed.toString();
+  }
   try {
-    return new URL(maybeRelative, SITE_URL).toString();
+    const parsed = new URL(maybeRelative, SITE_URL);
+    parsed.pathname = normalizePathname(parsed.pathname);
+    return parsed.toString();
   } catch (error) {
     return undefined;
   }
 };
 
 const canonicalURL =
-  resolveAbsoluteURL(canonical) ?? new URL(Astro.url.pathname, SITE_URL).toString();
+  resolveAbsoluteURL(canonical) ??
+  new URL(normalizePathname(Astro.url.pathname), SITE_URL).toString();
 const prevURL = resolveAbsoluteURL(relPrev);
 const nextURL = resolveAbsoluteURL(relNext);
 
@@ -89,22 +98,26 @@ const keywordsContent =
 // ✅ Absolute URL for organization logo
 const orgLogo = new URL("/logos/substack_logo.webp", SITE_URL).toString();
 
-// ✅ Organization structured data (improved: description + sameAs)
+// Keep organization minimal and secondary to the person entity.
 const orgSchema = {
   "@context": "https://schema.org",
   "@type": "Organization",
   "@id": `${SITE_URL}#organization`,
   url: SITE_URL,
   name: SITE_TITLE,
-  description: SITE_DESCRIPTION,
-  logo: {
-    "@type": "ImageObject",
-    url: orgLogo,
-  },
-  sameAs: SITE_ORG_SAME_AS,
 };
 
-// ✅ WebSite schema with SearchAction (always included)
+const personSchema = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "@id": `${SITE_URL}#person`,
+  name: SITE_AUTHOR,
+  url: SITE_AUTHOR_URL,
+  jobTitle: "Writer, Investor, and Advisor",
+  sameAs: SITE_AUTHOR_SAME_AS,
+};
+
+// WebSite schema (SearchAction removed because search page is noindex)
 const websiteSchema = {
   "@context": "https://schema.org",
   "@type": "WebSite",
@@ -112,39 +125,8 @@ const websiteSchema = {
   url: SITE_URL,
   name: SITE_TITLE,
   description: SITE_DESCRIPTION,
-  publisher: { "@id": `${SITE_URL}#organization` },
-  potentialAction: {
-    "@type": "SearchAction",
-    target: {
-      "@type": "EntryPoint",
-      urlTemplate: `${SITE_URL}writing/search?q={search_term_string}`,
-    },
-    "query-input": "required name=search_term_string",
-  },
+  publisher: { "@id": `${SITE_URL}#person` },
 };
-
-// ✅ Person schema (included on About page via includePerson prop)
-const personSchema = includePerson
-  ? {
-      "@context": "https://schema.org",
-      "@type": "Person",
-      "@id": `${SITE_URL}#person`,
-      name: SITE_AUTHOR,
-      url: SITE_AUTHOR_URL,
-      jobTitle: "Writer, Investor, and Advisor",
-      worksFor: { "@id": `${SITE_URL}#organization` },
-      knowsAbout: [
-        "Finance",
-        "Technology",
-        "Investing",
-        "Decision-Making",
-        "Investment Banking",
-        "Startups",
-        "Venture Capital",
-      ],
-      sameAs: SITE_AUTHOR_SAME_AS,
-    }
-  : null;
 
 // ✅ Article structured data (only if pubDate provided → means it's a blog post)
 let articleSchema;
@@ -158,11 +140,9 @@ if (pubDate) {
     datePublished: pubDate.toISOString(),
     dateModified: (updatedDate || pubDate).toISOString(),
     author: {
-      "@type": "Person",
-      name: resolvedAuthor,
-      url: SITE_AUTHOR_URL,
+      "@id": `${SITE_URL}#person`,
     },
-    publisher: { "@id": `${SITE_URL}#organization` },
+    publisher: { "@id": `${SITE_URL}#person` },
     mainEntityOfPage: {
       "@type": "WebPage",
       "@id": canonicalURL,
@@ -178,9 +158,9 @@ if (articleSchema && normalizedTags.length > 0) {
 
 const structuredData = [
   orgSchema,
+  personSchema,
   websiteSchema,
   ...(articleSchema ? [articleSchema] : []),
-  ...(personSchema ? [personSchema] : []),
 ];
 const ogImageAlt = `Preview image for ${title}`;
 ---
@@ -281,9 +261,10 @@ const ogImageAlt = `Preview image for ${title}`;
 <meta name="twitter:site" content="@leonlinsx" />
 
 <!-- ✅ Combined Structured Data -->
-<script is:inline type="application/ld+json">
-  {JSON.stringify(structuredData)}
-</script>
+<script
+  type="application/ld+json"
+  set:html={JSON.stringify(structuredData)}
+></script>
 
 <!-- Microsoft Clarity -->
 {import.meta.env.PROD && (


### PR DESCRIPTION
### Motivation
- Ensure canonical and sitemap URLs are normalized (consistent trailing slash handling) so `lastmod` lookups and canonical URLs match site routes.
- Simplify and correct JSON-LD structured data to prefer the person entity over a heavy organization object and remove SearchAction because the search page is noindex.
- Fix how the sitemap item URL is emitted to avoid mismatches between the sitemap `url` and `lastmod` lookup keys.

### Description
- Added a `normalizePathname` helper to `astro.config.mjs` and `BaseHead.astro` to strip or preserve trailing slashes consistently and applied it when serializing sitemap entries and building canonical URLs.
- Updated sitemap `serialize` to normalize the pathname, update the `url` returned to a normalized string, and use the normalized pathname to lookup `lastmod` from `blogLastmod`.
- Reworked structured data in `BaseHead.astro` to: always include a minimal `Person` schema, remove non-essential organization fields (`description`, `logo`, `sameAs`), set `WebSite.publisher` to the person entity, and reference the person (`@id`) for article `author` and `publisher`.
- Removed conditional `includePerson` prop and the `SearchAction` from `WebSite` schema since the search page is excluded from indexing.
- Normalized absolute URL resolution in `resolveAbsoluteURL` to ensure paths are normalized for any provided absolute or relative URLs, and used the normalizer when computing `canonicalURL`, `prevURL`, and `nextURL`.
- Changed the JSON-LD injection to use `set:html` for the script tag in Astro to ensure the JSON is inlined correctly at runtime.
- Cleaned up imports in `BaseHead.astro` by removing the unused `SITE_ORG_SAME_AS` constant.

### Testing
- Ran a production build with `npm run build` (Astro build) and the build succeeded without errors.
- Generated the sitemap and verified entries use normalized URLs and that `lastmod` values are present for blog posts during the build (automated generation succeeded).
- Ran project linting (`npm run lint`) and static checks which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd66bff8bc83279706863351340835)