### PR TITLE
Sanitize and fix JSON-LD rendering to prevent parsing errors

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -9,6 +9,7 @@ import {
   SITE_AUTHOR_URL,
   SITE_AUTHOR_SAME_AS,
 } from "../consts";
+import { sanitizeJsonLd } from '../utils/jsonld';
 
 const {
   title,
@@ -156,12 +157,23 @@ if (articleSchema && normalizedTags.length > 0) {
   articleSchema.keywords = normalizedTags.join(", ");
 }
 
-const structuredData = [
+const structuredDataGraph = [
   orgSchema,
   personSchema,
   websiteSchema,
   ...(articleSchema ? [articleSchema] : []),
 ];
+
+const structuredData = sanitizeJsonLd({
+  '@context': 'https://schema.org',
+  '@graph': structuredDataGraph.map((entry) => {
+    if (entry && typeof entry === 'object' && '@context' in entry) {
+      const { ['@context']: _context, ...rest } = entry as Record<string, unknown>;
+      return rest;
+    }
+    return entry;
+  }),
+});
 const ogImageAlt = `Preview image for ${title}`;
 ---
 

--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -1,5 +1,6 @@
 ---
 import { SITE_URL } from '../consts';
+import { sanitizeJsonLd } from '../utils/jsonld';
 
 interface BreadcrumbItem {
   label: string;
@@ -14,6 +15,12 @@ const breadcrumbList = items.map((item, index) => ({
   name: item.label,
   item: item.href ? new URL(item.href, SITE_URL).toString() : undefined,
 }));
+
+const breadcrumbSchema = sanitizeJsonLd({
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: breadcrumbList,
+});
 ---
 
 {items.length > 1 && (
@@ -32,13 +39,10 @@ const breadcrumbList = items.map((item, index) => ({
         );
       })}
     </ol>
-    <script is:inline type="application/ld+json">
-      {JSON.stringify({
-        '@context': 'https://schema.org',
-        '@type': 'BreadcrumbList',
-        itemListElement: breadcrumbList,
-      })}
-    </script>
+    <script
+      type="application/ld+json"
+      set:html={JSON.stringify(breadcrumbSchema)}
+    ></script>
   </nav>
 )}
 

--- a/src/utils/jsonld.ts
+++ b/src/utils/jsonld.ts
@@ -1,0 +1,48 @@
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  return Object.prototype.toString.call(value) === '[object Object]';
+};
+
+export const sanitizeJsonLd = (value: unknown): unknown => {
+  if (value === null) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (Array.isArray(value)) {
+    const sanitizedItems = value
+      .map((item) => sanitizeJsonLd(item))
+      .filter((item) => item !== undefined);
+    return sanitizedItems;
+  }
+
+  if (isPlainObject(value)) {
+    const sanitizedObject = Object.entries(value).reduce<Record<string, unknown>>(
+      (acc, [key, nestedValue]) => {
+        const sanitizedValue = sanitizeJsonLd(nestedValue);
+        if (sanitizedValue !== undefined) {
+          acc[key] = sanitizedValue;
+        }
+        return acc;
+      },
+      {},
+    );
+
+    return sanitizedObject;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  if (
+    typeof value === 'string' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
### Motivation
- Built pages sometimes contained template artifacts (`{JSON.stringify(...)}`) and non-serializable values which caused Google Search Console parsing errors like “Missing '}' or object member name”.
- Structured data generation lacked sanitization so `undefined`, non-finite numbers, or template expressions could leak into emitted JSON-LD and break `JSON.parse`.
- Keep structured data shape and schema types unchanged while making output safe for production consumers.

### Description
- Add a small recursive sanitizer `sanitizeJsonLd` in `src/utils/jsonld.ts` that strips `undefined`, non-finite numbers, non-JSON types, and converts `Date` instances to ISO strings. 
- Harden `BaseHead.astro` to build a single JSON-LD payload `{ "@context": "https://schema.org", "@graph": [...] }`, remove nested per-node `@context` entries, and sanitize before `JSON.stringify` to ensure only JSON-safe values are emitted. 
- Fix breadcrumb emission in `Breadcrumbs.astro` to produce an actual JSON string at build-time by using `set:html={JSON.stringify(breadcrumbSchema)}` and sanitize the breadcrumb payload first. 
- Files changed: `src/utils/jsonld.ts`, `src/components/BaseHead.astro`, `src/components/Breadcrumbs.astro`.

### Testing
- Ran `npm run build` and the build completed successfully with static output in `dist/`. 
- Extracted JSON-LD script contents from built HTML and validated with `JSON.parse` for `dist/index.html`, `dist/writing/excel/index.html`, and `dist/writing/convert/index.html`, and all parsed without errors. 
- Confirmed no template artifacts remain by searching `dist/` for occurrences of the template serialization pattern (e.g. `rg "\{JSON\.stringify\(" dist -n`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd76fa12048327bd4069450102e75c)